### PR TITLE
Fix failing tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,10 +63,6 @@ jobs:
         collation server: 'utf8mb4_general_ci'
 
     - name: Run tests
-      shell: bash
-      run: echo "$DATABASE_USER"
-
-    - name: Run tests
       run: pnpm run test
       env:
         DATABASE_PORT: 3307

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,8 +62,11 @@ jobs:
         character set server: 'utf8mb4'
         collation server: 'utf8mb4_general_ci'
 
-    - name: Start docker containers
-      run: cd server && docker-compose up -d
+    - uses: hoverkraft-tech/compose-action@v2.0.1
+      with:
+        compose-file: "./server/docker-compose.yml"
+        services: |
+          rabbitmq
       
     - name: Run tests
       run: pnpm run test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,6 +62,9 @@ jobs:
         character set server: 'utf8mb4'
         collation server: 'utf8mb4_general_ci'
 
+    - name: Start docker containers
+      run: cd server && docker-compose up -d
+      
     - name: Run tests
       run: pnpm run test
       env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,7 +63,7 @@ jobs:
         collation server: 'utf8mb4_general_ci'
 
     - name: Run tests
-      run: pnpm run test
+      run: env
       env:
         DATABASE_PORT: 3307
         DATABASE_USER: "edithing"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,7 +63,11 @@ jobs:
         collation server: 'utf8mb4_general_ci'
 
     - name: Run tests
-      run: env
+      shell: bash
+      run: echo "$DATABASE_USER"
+
+    - name: Run tests
+      run: pnpm run test
       env:
         DATABASE_PORT: 3307
         DATABASE_USER: "edithing"

--- a/server/src/integration/database/connection.ts
+++ b/server/src/integration/database/connection.ts
@@ -9,9 +9,6 @@ export const setConnection = (ds: DataSource) => {
 };
 
 export const initConnection = async () => {
-    console.log(database);
-    console.log(JSON.stringify(process.env));
-    
     await createDatabase({ ifNotExist: true, options: database });
 
     if (!connection) {

--- a/server/src/integration/database/connection.ts
+++ b/server/src/integration/database/connection.ts
@@ -9,6 +9,8 @@ export const setConnection = (ds: DataSource) => {
 };
 
 export const initConnection = async () => {
+    console.log(database);
+    
     await createDatabase({ ifNotExist: true, options: database });
 
     if (!connection) {

--- a/server/src/integration/database/connection.ts
+++ b/server/src/integration/database/connection.ts
@@ -10,6 +10,7 @@ export const setConnection = (ds: DataSource) => {
 
 export const initConnection = async () => {
     console.log(database);
+    console.log(JSON.stringify(process.env));
     
     await createDatabase({ ifNotExist: true, options: database });
 

--- a/turbo.json
+++ b/turbo.json
@@ -4,8 +4,7 @@
   "tasks": {
     "build": {
       "dependsOn": ["^build"],
-      "outputs": ["dist/**", ".next/**", "build/**"],
-      "env": ["DATABASE_PORT", "DATABASE_USER", "DATABASE_NAME", "DATABASE_PASSWORD"]
+      "outputs": ["dist/**", ".next/**", "build/**"]
     },
     "lint": {
       "outputs": []
@@ -18,7 +17,8 @@
       "cache": false
     },
     "test": {
-      "outputs": [""]
+      "outputs": [""],
+      "env": ["DATABASE_PORT", "DATABASE_USER", "DATABASE_NAME", "DATABASE_PASSWORD"]
     },
     "typecheck": {
       "outputs": []

--- a/turbo.json
+++ b/turbo.json
@@ -5,7 +5,7 @@
     "build": {
       "dependsOn": ["^build"],
       "outputs": ["dist/**", ".next/**", "build/**"],
-      "env": ["DATABASE_PORT", "DATABASE_USER", "DATABASE_NAME", "DATABASE_PASSWORD"],
+      "env": ["DATABASE_PORT", "DATABASE_USER", "DATABASE_NAME", "DATABASE_PASSWORD"]
     },
     "lint": {
       "outputs": []

--- a/turbo.json
+++ b/turbo.json
@@ -4,7 +4,8 @@
   "tasks": {
     "build": {
       "dependsOn": ["^build"],
-      "outputs": ["dist/**", ".next/**", "build/**"]
+      "outputs": ["dist/**", ".next/**", "build/**"],
+      "env": ["DATABASE_PORT", "DATABASE_USER", "DATABASE_NAME", "DATABASE_PASSWORD"],
     },
     "lint": {
       "outputs": []


### PR DESCRIPTION
This patch fixes the broken tests.

One reason the tests fail, as seen [here](https://github.com/althingi-net/edithing/actions/runs/14970154145/job/42049056422#step:12:1282), is that environmental variables were not accessible because Turbo [removed them](https://turborepo.com/docs/crafting-your-repository/using-environment-variables#adding-environment-variables-to-task-hashes). The patch ensures that they are available during run-time.

Another reason was that RabbitMQ was [not started](https://github.com/althingi-net/edithing/actions/runs/14971182742/job/42052273291#step:12:1308). The patch ensures that it is started before tests are run.