### PR TITLE
Add authorization headers for POST/PUT requests

### DIFF
--- a/server/.env.sample
+++ b/server/.env.sample
@@ -13,3 +13,4 @@ MESSAGE_BROKER_URL="amqp://guest:guest@127.0.0.1:5672"
 
 # Lagasafn-XML
 LAGASAFN_API_URL="https://lagasafn.althingi.net/api/bill/validate"
+LAGASAFN_API_ACCESS_TOKEN="supersecret"

--- a/server/src/config/lagasafnApi.ts
+++ b/server/src/config/lagasafnApi.ts
@@ -1,3 +1,4 @@
 export const lagasafnApi = {
     url: process.env.LAGASAFN_API_URL || 'https://lagasafn.althingi.net/api/bill/validate',
+    api_access_token: process.env.LAGASAFN_API_ACCESS_TOKEN || '',
 };

--- a/server/src/integration/lagasafnApi/index.ts
+++ b/server/src/integration/lagasafnApi/index.ts
@@ -31,7 +31,7 @@ export const postBillForValidation = async (billXml: string) => {
 };
 
 export const postBillForPublishing = async (billNr: number, billXml: string) => {
-    const url = lagasafnApi.url + '/api/bill/' + String( billNr ) + '/document/publish';
+    const url = `${lagasafnApi.url}/api/bill/${billNr}/document/publish`;
 
     try {
         await axios.post(url, billXml, getConfig());

--- a/server/src/integration/lagasafnApi/index.ts
+++ b/server/src/integration/lagasafnApi/index.ts
@@ -16,7 +16,7 @@ export const postBillMeta = async (billMetaXml: string) => {
     try {
         await axios.post(url, billMetaXml, getConfig());
     } catch (error: any) {
-        throw new Error( <string>( error?.response.data?.message ?? 'Unknown error' ) );
+        console.log('Request to lagasafn failed', error);
     }
 };
 
@@ -26,7 +26,7 @@ export const postBillForValidation = async (billXml: string) => {
     try {
         await axios.post(url, billXml, getConfig());
     } catch (error: any) {
-        throw new Error( <string>( error?.response.data?.message ?? 'Unknown error' ) );
+        console.log('Request to lagasafn failed', error);
     }
 };
 
@@ -36,6 +36,6 @@ export const postBillForPublishing = async (billNr: number, billXml: string) => 
     try {
         await axios.post(url, billXml, getConfig());
     } catch (error: any) {
-        throw new Error( <string>( error?.response.data?.message ?? 'Unknown error' ) );
+        console.log('Request to lagasafn failed', error);
     }
 };

--- a/server/src/integration/lagasafnApi/index.ts
+++ b/server/src/integration/lagasafnApi/index.ts
@@ -1,28 +1,40 @@
 import axios from 'axios';
 import { lagasafnApi } from '../../config/lagasafnApi';
 
-axios.defaults.headers.post['Content-Type'] = 'application/xml';
-axios.defaults.headers.post['Authorization'] = 'Bearer ' + lagasafnApi.api_access_token;
+const getConfig = () => {
+    return {
+        headers: {
+            'Content-Type': 'application/xml',
+            'Authorization': 'Bearer ' + lagasafnApi.api_access_token,
+        },
+    };
+};
 
 export const postBillMeta = async (billMetaXml: string) => {
+    const url = lagasafnApi.url + '/api/bill/meta';
+
     try {
-        await axios.post(lagasafnApi.url + '/api/bill/meta', billMetaXml);
+        await axios.post(url, billMetaXml, getConfig());
     } catch (error: any) {
         throw new Error( <string>( error?.response.data?.message ?? 'Unknown error' ) );
     }
 };
 
 export const postBillForValidation = async (billXml: string) => {
+    const url = lagasafnApi.url + '/api/bill/document/validate';
+
     try {
-        await axios.post(lagasafnApi.url + '/api/bill/document/validate', billXml);
+        await axios.post(url, billXml, getConfig());
     } catch (error: any) {
         throw new Error( <string>( error?.response.data?.message ?? 'Unknown error' ) );
     }
 };
 
 export const postBillForPublishing = async (billNr: number, billXml: string) => {
+    const url = lagasafnApi.url + '/api/bill/' + String( billNr ) + '/document/publish';
+
     try {
-        await axios.post(lagasafnApi.url + '/api/bill/' + String( billNr ) + '/document/publish', billXml);
+        await axios.post(url, billXml, getConfig());
     } catch (error: any) {
         throw new Error( <string>( error?.response.data?.message ?? 'Unknown error' ) );
     }

--- a/server/src/integration/lagasafnApi/index.ts
+++ b/server/src/integration/lagasafnApi/index.ts
@@ -2,6 +2,7 @@ import axios from 'axios';
 import { lagasafnApi } from '../../config/lagasafnApi';
 
 axios.defaults.headers.post['Content-Type'] = 'application/xml';
+axios.defaults.headers.post['Authorization'] = 'Bearer ' + lagasafnApi.api_access_token;
 
 export const postBillMeta = async (billMetaXml: string) => {
     try {


### PR DESCRIPTION
This patch adds authorization headers for `POST`/`PUT` requests to lagasafn API. 

Relevant change for lagasafn API: https://github.com/althingi-net/lagasafn-xml/pull/35